### PR TITLE
Fix bug in output size calculation for compression

### DIFF
--- a/lzomodule.c
+++ b/lzomodule.c
@@ -80,7 +80,7 @@ compress(PyObject *dummy, PyObject *args)
     if (len < 0)
         return NULL;
     in_len = len;
-    out_len = in_len + in_len / 64 + 16 + 3;
+    out_len = in_len + in_len / 16 + 64 + 3;
 
     /* alloc buffers */
     result_str = PyString_FromStringAndSize(NULL, 5 + out_len);

--- a/lzomodule.c
+++ b/lzomodule.c
@@ -159,7 +159,7 @@ decompress(PyObject *dummy, PyObject *args)
         goto header_error;
     in_len = len - 5;
     out_len = (in[1] << 24) | (in[2] << 16) | (in[3] << 8) | in[4];
-    if ((int)out_len < 0 || in_len > out_len + out_len / 64 + 16 + 3)
+    if ((int)out_len < 0 || in_len > out_len + out_len / 16 + 64 + 3)
         goto header_error;
 
     /* alloc buffers */
@@ -215,7 +215,7 @@ optimize(PyObject *dummy, PyObject *args)
         goto header_error;
     in_len = len - 5;
     out_len = (in[1] << 24) | (in[2] << 16) | (in[3] << 8) | in[4];
-    if ((int)out_len < 0 || in_len > out_len + out_len / 64 + 16 + 3)
+    if ((int)out_len < 0 || in_len > out_len + out_len / 16 + 64 + 3)
         goto header_error;
 
     /* alloc buffers */


### PR DESCRIPTION
The math used to compute the size of the output buffer was incorrect,
according to the LZO.FAQ document from version 2.08 of the LZO
distribution.