### PR TITLE
Make python 3.5 the python3 used in tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27,py34
+envlist = py27,py35
 [testenv]
 deps=
     nose


### PR DESCRIPTION
This is driven by it now being the standard in Ubuntu 16.04