### PR TITLE
fix include dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if sys.platform == "win32":
     extra_objects.append(lib_file)
 else:
     libraries = ["lzo2"]
-    include_dirs.append(os.environ.get("PREFIX", "/usr")+"/include/lzo")
+    include_dirs.append(os.environ.get("PREFIX", "/usr")+"/include")
     ##library_dirs.append("/usr/local/lib")
     ##runtime_library_dirs.append("/usr/local/lib")
 


### PR DESCRIPTION
Accounting for the changes made in 2882456bd57f45a7761c320d3e46dfd91f620583
Without this change header files are looked for in `PREFIX/include/lzo/lzo/lzo1x.h` rather than `PREFIX/include/lzo/lzo1x.h`.