### PR TITLE
Added support for compression and decompression using all algorithms supported by LZO C library 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,12 @@ environment:
     # isn't covered by this document) at the time of writing.
 
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
-    # - PYTHON: "C:\\Python27-x64"
-    # - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python39"
+    - PYTHON: "C:\\Python39-x64"    
     #   DISTUTILS_USE_SDK: "1"
     # - PYTHON: "C:\\Python35-x64"
 

--- a/lzomodule.c
+++ b/lzomodule.c
@@ -79,17 +79,17 @@ typedef int (*lzo_decompress_fn)(const lzo_bytep, lzo_uint, lzo_bytep, lzo_uintp
 ************************************************************************/
 
 static /* const */ char compress__doc__[] =
-"compress(string[,algorithm[,level[,header]]]) -- Compress string, returning a string "
+"compress(string[,level[,header[,algorithm]]]) -- Compress string, returning a string "
 "containing compressed data.\n"
-"algorithm  - can be either LZO1, LZO1A, LZO1B, LZO1C, LZO1F, LZO1X, LZO1Y, LZO1Z, LZO2A."
-"(default: LZO1X).\n"
 "level  - Set compression level of either 1 (default) or 9.\n"
 "header - Include metadata header for decompression in the output "
 "(default: True).\n"
+"algorithm (keyword argument)  - can be either LZO1, LZO1A, LZO1B, LZO1C, LZO1F, LZO1X, LZO1Y, LZO1Z, LZO2A."
+"(default: LZO1X).\n"
 ;
 
 static PyObject *
-compress(PyObject *dummy, PyObject *args)
+compress(PyObject *dummy, PyObject *args, PyObject *kwds)
 {
     PyObject *result_str;
     lzo_voidp wrkmem = NULL;
@@ -104,6 +104,7 @@ compress(PyObject *dummy, PyObject *args)
     int header = 1;
     int err;
 
+    static char* argnames[] = {"", "", "", "algorithm", NULL};
     char *algorithm = "LZO1X";
     lzo_compress_fn compress_1_ptr;
     lzo_compress_fn compress_999_ptr;
@@ -112,7 +113,7 @@ compress(PyObject *dummy, PyObject *args)
 
     /* init */
     UNUSED(dummy);
-    if (!PyArg_ParseTuple(args, "s#|sii", &in, &len, &algorithm, &level, &header))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s#|ii$s", argnames, &in, &len, &level, &header, &algorithm))
         return NULL;
     if (len < 0)
         return NULL;
@@ -280,16 +281,16 @@ compress(PyObject *dummy, PyObject *args)
 ************************************************************************/
 
 static /* const */ char decompress__doc__[] =
-"decompress(string[,algorithm[,header[,buflen]]]) -- Decompress the data in string, returning a string containing the decompressed data.\n"
+"decompress(string[,header[,buflen[,algorithm]]]) -- Decompress the data in string, returning a string containing the decompressed data.\n"
 "header - Metadata header is included in input (default: True).\n"
-"algorithm  - can be either LZO1, LZO1A, LZO1B, LZO1C, LZO1F, LZO1X, LZO1Y, LZO1Z, LZO2A."
-"(default: LZO1X).\n"
 "buflen - If header is False, a buffer length in bytes must be given that "
 "will fit the output.\n"
+"algorithm (keyword argument) - can be either LZO1, LZO1A, LZO1B, LZO1C, LZO1F, LZO1X, LZO1Y, LZO1Z, LZO2A."
+"(default: LZO1X).\n"
 ;
 
 static PyObject *
-decompress(PyObject *dummy, PyObject *args)
+decompress(PyObject *dummy, PyObject *args, PyObject *kwds)
 {
     PyObject *result_str;
     const lzo_bytep in;
@@ -302,12 +303,13 @@ decompress(PyObject *dummy, PyObject *args)
     int header = 1;
     int err;
 
+    static char* argnames[] = {"", "", "", "algorithm", NULL};
     char *algorithm = "LZO1X";
     lzo_decompress_fn decompress_ptr;
 
     /* init */
     UNUSED(dummy);
-    if (!PyArg_ParseTuple(args, "s#|sii", &in, &len, &algorithm, &header, &buflen))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s#|ii$s", argnames, &in, &len, &header, &buflen, &algorithm))
         return NULL;
     if (header) {
         if (len < 5 + 3 || in[0] < 0xf0 || in[0] > 0xf1)
@@ -564,9 +566,9 @@ crc32(PyObject *dummy, PyObject *args)
 static /* const */ PyMethodDef methods[] =
 {
     {"adler32",    (PyCFunction)adler32,    METH_VARARGS, adler32__doc__},
-    {"compress",   (PyCFunction)compress,   METH_VARARGS, compress__doc__},
+    {"compress",   (PyCFunction)compress,   METH_VARARGS | METH_KEYWORDS, compress__doc__},
     {"crc32",      (PyCFunction)crc32,      METH_VARARGS, crc32__doc__},
-    {"decompress", (PyCFunction)decompress, METH_VARARGS, decompress__doc__},
+    {"decompress", (PyCFunction)decompress, METH_VARARGS | METH_KEYWORDS, decompress__doc__},
     {"optimize",   (PyCFunction)optimize,   METH_VARARGS, optimize__doc__},
     {NULL, NULL, 0, NULL}
 };

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ ext = Extension(
 
 setup_args = get_kw(
     name="python-lzo",
-    version="1.15",
+    version="1.16",
     description="Python bindings for the LZO data compression library",
     author="Markus F.X.J. Oberhumer",
     author_email="markus@oberhumer.com",

--- a/tests/test.py
+++ b/tests/test.py
@@ -31,7 +31,7 @@
 ##---------------------------------------------------------------------------##
 
 from __future__ import print_function
-
+import inspect
 import sys, string
 
 # update sys.path when running in the build directory
@@ -56,10 +56,10 @@ def print_modinfo():
 
 def gen(src, level=1):
     a0 = lzo.adler32(src)
-    c =  lzo.compress(src, level)
+    c  = lzo.compress(src, level)
     u1 = lzo.decompress(c)
     a1 = lzo.adler32(u1)
-    o =  lzo.optimize(c)
+    o  = lzo.optimize(c)
     u2 = lzo.decompress(o)
     a2 = lzo.adler32(u2)
     if src != u1:
@@ -70,13 +70,30 @@ def gen(src, level=1):
         raise lzo.error("internal error 2")
     print("compressed %6d -> %6d" % (len(src), len(c)))
 
+def gen_all(src):
+    all_algos = {"LZO1", "LZO1A", "LZO1B", "LZO1C", "LZO1F", "LZO1X", "LZO1Y", "LZO1Z", "LZO2A"}
+    if not src:
+        # LZO1 and LZO1A header exception for empty input
+        all_algos.remove("LZO1")
+        all_algos.remove("LZO1A")
+    for algo in all_algos:
+        a0 = lzo.adler32(src)
+        c  = lzo.compress(src, algorithm=algo)
+        u1 = lzo.decompress(c, algorithm=algo)
+        a1 = lzo.adler32(u1)
+        if src != u1:
+            raise lzo.error("internal error 1: %r %r", src, u1)
+        if a0 != a1:
+            raise lzo.error("internal error 2")
+        print(f"compressed using {algo} {len(src): 6} -> {len(c): 6}")
+
 
 def gen_raw(src, level=1):
     a0 = lzo.adler32(src)
-    c =  lzo.compress(src, level, False)
+    c  = lzo.compress(src, level, False)
     u1 = lzo.decompress(c, False, len(src))
     a1 = lzo.adler32(u1)
-    o =  lzo.optimize(c, False, len(src))
+    o  = lzo.optimize(c, False, len(src))
     u2 = lzo.decompress(o, False, len(src))
     a2 = lzo.adler32(u2)
     # make sure it still works when you overstate the output buffer length
@@ -99,6 +116,10 @@ def test_lzo():
     yield gen, b"abcabcabcabcabcabcabcabc"
     yield gen, b"abcabcabcabcabcabcabcabc", 9
 
+def test_lzo_all():
+    yield gen_all, b"aaaaaaaaaaaaaaaaaaaaaaaa"
+    yield gen_all, b"abcabcabcabcabcabcabcabc"
+    yield gen_all, b"abcabcabcabcabcabcabcabc"
 
 def test_lzo_raw():
     yield gen_raw, b"aaaaaaaaaaaaaaaaaaaaaaaa"
@@ -110,10 +131,12 @@ def test_lzo_empty():
     yield gen, b""
     yield gen_raw, b""
 
+def test_lzo_empty_all():
+    yield gen_all, b""
 
 def test_lzo_big():
     gen(b" " * 131072)
-
+    gen_all(b" " * 131072)
 
 def test_lzo_raw_big():
     gen_raw(b" " * 131072)
@@ -124,3 +147,14 @@ if sys.maxsize > 1<<32:
     # this much data requires a 64-bit system.
     def test_lzo_compress_extremely_big():
         b = lzo.compress(bytes(bytearray((1024**3)*2)))
+
+if __name__ == "__main__":
+    all_tests = (test_lzo, test_lzo_raw, test_lzo_empty, test_lzo_big, test_lzo_raw_big, test_lzo_all, test_lzo_empty_all)
+    for test_func in all_tests:
+        if inspect.isgeneratorfunction(test_func) is True:
+            for test_case in test_func():
+                test = test_case[0]
+                args = test_case[1:]
+                test(*args)
+        else:
+            test_func()


### PR DESCRIPTION
Added LZO1, LZO1A, LZO1B, LZO1C, LZO1F, LZO1X, LZO1Y, LZO1Z, LZO2A and LZO1X (default) as optional parameters in compress and decompress functions.

resolves #53 , resolves #24. Was not sure if version should be updated to 1.16 or not, set it up as 1.16 in the pr.

Further Improvements and suggestions are solicited.

Thanks.