### PR TITLE
Provide Windows wheels

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,56 @@
+name: Build wheels for Windows x64
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-w64:
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    name: ${{ matrix.python-version }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Download lzo and extract it
+        run: |
+          if not exist C:\src\ (md C:\src)
+          if not exist C:\src\lzo-2.10.tar.gz (curl -fsS http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz -o C:\src\lzo-2.10.tar.gz)
+          python tarxfz.py
+      - name: Run cmake
+        working-directory: C:\src\lzo-2.10
+        run: |
+          md build
+          cd build
+          cmake ..
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          msbuild-architecture: x64
+      - name: Build lzo static lib
+        working-directory: C:\src\lzo-2.10\build
+        run: msbuild lzo_static_lib.vcxproj -p:Configuration=Release;Platform=x64;OutDir=C:\src\lzo-2.10
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Build wheel
+        env:
+          LZO_DIR: C:\src\lzo-2.10
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U wheel
+          python setup.py bdist_wheel
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+          if-no-files-found: error


### PR DESCRIPTION
I don't expect this to be merged as is but maybe it can help.

This is the workflow I used to build wheels for Windows. In its current state you have to manually run it.

Some modifications could be made to build from the lzo that's included in the repo and to upload the wheels to PyPI on release.

This would close #19, #39, #49 and #55.

Also here are build instructions for Windows that could be added to the readme to close #51:

For `lzo2.lib`:
  1. You need [cmake](https://cmake.org/download/) and [msbuild](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
  2. Clone the repo (optional if you just want `lzo2.lib` and not the wheel)
  3. Download [lzo](http://www.oberhumer.com/opensource/lzo/download/) and extract it, or use the one from the cloned repo
  4. At the root of the lzo directory create a `build` directory and `cd` into it
  5. Run `cmake ..`
  6. Run `msbuild lzo_static_lib.vcxproj -p:Configuration=Release;Platform=x64`
  7. `lzo2.lib` will be in the `Release` directory

For the wheel:
  1. `cd` to the root of the cloned repo
  2. Run `set LZO_DIR=C:\path\to\dir` where `dir` contains `lzo2.lib`
  3. `pip install -U wheel`
  4. `python setup.py bdist_wheel`
  5. The wheel is in the `dist` directory

It would be nice if you could add 1.14 wheels to PyPI for future Windows users and to avoid new issues about installation.

In the meantime wheels can be found [here](https://github.com/AT0myks/reolink-fw/releases/tag/v1.0.0) if someone wants them. They were built from lzo 2.10 and the repo in [this state](https://github.com/jd-boyd/python-lzo/tree/eb5610c216b50bb307fcdf78e1e3ee4567b0915a), and target CPython for Windows x64.