### PR TITLE
Migrate from nose to pytest as nose is now all but dead upstream

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
            fi
            echo LZO SETUP DONE
       - run: python setup.py install
-      - run: pip install nose wheel
-      - run: nosetests --with-doctest tests/
+      - run: pip install pytest wheel
+      - run: pytest --doctest-modules tests/
       - run: ls -l
       - run: python setup.py sdist bdist_wheel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ environment:
 
 install:
   - cmd: |
-      "%PYTHON%\\python.exe" -m pip install nose
+      "%PYTHON%\\python.exe" -m pip install pytest
       if not exist C:\\src\\ (md C:\\src\\)
       if not exist C:\\src\\lzo-2.10.tar.gz (curl -fsS http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz -o C:\\src\\lzo-2.10.tar.gz)
       "%PYTHON%\\python.exe" tarxfz.py

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class TestCommand(Command):
         raise SystemExit(
             subprocess.call([sys.executable,
                              '-m',
-                             'nose']))
+                             'pytest']))
 
 
 if sys.platform == "win32":
@@ -107,7 +107,7 @@ setup_args = get_kw(
     maintainer_email="jdboyd@jdboyd.net",
     url="https://github.com/jd-boyd/python-lzo",
     license="GNU General Public License (GPL)",
-    tests_require=['nose'],
+    tests_require=['pytest'],
     cmdclass={
         'test': TestCommand
     },

--- a/tests/test_lzo.py
+++ b/tests/test_lzo.py
@@ -32,6 +32,7 @@
 
 from __future__ import print_function
 import inspect
+import pytest
 import sys, string
 
 # update sys.path when running in the build directory
@@ -111,34 +112,35 @@ def test_version():
     assert pkg_version == mod_version, \
         "%r != %r" %(pkg_version, mod_version)
 
-def test_lzo():
-    yield gen, b"aaaaaaaaaaaaaaaaaaaaaaaa"
-    yield gen, b"abcabcabcabcabcabcabcabc"
-    yield gen, b"abcabcabcabcabcabcabcabc", 9
+@pytest.mark.parametrize("src, level", [(b"aaaaaaaaaaaaaaaaaaaaaaaa", 1), (b"abcabcabcabcabcabcabcabc", 1), (b"abcabcabcabcabcabcabcabc", 9)])
+def test_lzo(src, level):
+    gen(src, level)
 
-def test_lzo_all():
-    yield gen_all, b"aaaaaaaaaaaaaaaaaaaaaaaa"
-    yield gen_all, b"abcabcabcabcabcabcabcabc"
-    yield gen_all, b"abcabcabcabcabcabcabcabc"
+@pytest.mark.parametrize("src", [b"aaaaaaaaaaaaaaaaaaaaaaaa", b"abcabcabcabcabcabcabcabc"])
+def test_lzo_all(src):
+    gen_all(src)
 
-def test_lzo_raw():
-    yield gen_raw, b"aaaaaaaaaaaaaaaaaaaaaaaa"
-    yield gen_raw, b"abcabcabcabcabcabcabcabc"
-    yield gen_raw, b"abcabcabcabcabcabcabcabc", 9
+@pytest.mark.parametrize("src, level", [(b"aaaaaaaaaaaaaaaaaaaaaaaa", 1), (b"abcabcabcabcabcabcabcabc", 1), (b"abcabcabcabcabcabcabcabc", 9)])
+def test_lzo_raw(src, level):
+    gen_raw(src, level)
 
 
 def test_lzo_empty():
-    yield gen, b""
-    yield gen_raw, b""
+    gen(b"")
 
 def test_lzo_empty_all():
-    yield gen_all, b""
+    gen_all(b"")
+
+def test_lzo_empty_raw():
+    gen_raw(b"")
 
 def test_lzo_big():
     gen(b" " * 131072)
+
+def test_lzo_big_all():
     gen_all(b" " * 131072)
 
-def test_lzo_raw_big():
+def test_lzo_big_raw():
     gen_raw(b" " * 131072)
 
 
@@ -147,14 +149,3 @@ if sys.maxsize > 1<<32:
     # this much data requires a 64-bit system.
     def test_lzo_compress_extremely_big():
         b = lzo.compress(bytes(bytearray((1024**3)*2)))
-
-if __name__ == "__main__":
-    all_tests = (test_lzo, test_lzo_raw, test_lzo_empty, test_lzo_big, test_lzo_raw_big, test_lzo_all, test_lzo_empty_all)
-    for test_func in all_tests:
-        if inspect.isgeneratorfunction(test_func) is True:
-            for test_case in test_func():
-                test = test_case[0]
-                args = test_case[1:]
-                test(*args)
-        else:
-            test_func()

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,5 @@
 envlist = py27,py37
 [testenv]
 deps=
-    nose
-commands=nosetests  # or 'nosetests' or ...
-#commands=python tests/test.py
+    pytest
+commands=pytest


### PR DESCRIPTION
The `yield` mechanism is no longer supported in pytest, so this has been replaced with `@pytest.mark.parametrize`. However, this means executing the tests directly as `__main__` can no longer work.