### PR TITLE
Stop excluding python 3.11 on Windows-latest.

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   build-w64:
     runs-on: macos-12
-    defaults:
-      run:
-        shell: cmd
     strategy:
       matrix:
         python-version: ["3.7", "3.8"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,8 +60,6 @@ jobs:
             python-version: '3.11'
           - os: macos-10.15
             python-version: '3.11'
-          - os: windows-latest
-            python-version: '3.11'
     runs-on:  ${{ matrix.os }}
     name: ${{ matrix.os }} @ ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
Don't try to use cmd instead of bash on macos builds.