### PR TITLE
Stop excluding python 3.11 on Windows-latest.

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   build-w64:
     runs-on: macos-12
-    defaults:
-      run:
-        shell: cmd
     strategy:
       matrix:
         python-version: ["3.7", "3.8"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,9 +17,9 @@ jobs:
           - pypy-3.7
         os:
           - ubuntu-latest
-          - macos-10.15
+#          - macos-10.15
 #          - macos-11
-#          - macos-12
+          - macos-12
           - macos-latest
           - windows-latest
         exclude:
@@ -59,8 +59,6 @@ jobs:
           - os: macos-11
             python-version: '3.11'
           - os: macos-10.15
-            python-version: '3.11'
-          - os: windows-latest
             python-version: '3.11'
     runs-on:  ${{ matrix.os }}
     name: ${{ matrix.os }} @ ${{ matrix.python-version }}


### PR DESCRIPTION
Don't try to use cmd instead of bash on macos builds.

Switch macos 10.15 testing to 12.  10.15 runners take forever to be available.