### PR TITLE
3.12 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
             with:
                 platforms: all
           - name: Build and test wheels
-            uses: pypa/cibuildwheel@v2.12.3
+            uses: pypa/cibuildwheel@v2.16.2
             env:
                 CIBW_BUILD: "*${{ matrix.arch }}"
           - name: Upload wheels

--- a/tests/test_lzo.py
+++ b/tests/test_lzo.py
@@ -106,8 +106,12 @@ def gen_raw(src, level=1):
     print("compressed %6d -> %6d" % (len(src), len(c)))
 
 def test_version():
-    import pkg_resources
-    pkg_version = pkg_resources.require("python-lzo")[0].version
+    if sys.version_info >= (3, 10):
+        from importlib.metadata import version
+        pkg_version = version("python-lzo")
+    else:
+        import pkg_resources
+        pkg_version = pkg_resources.require("python-lzo")[0].version
     mod_version = lzo.__version__.decode('utf-8')
     assert pkg_version == mod_version, \
         "%r != %r" %(pkg_version, mod_version)

--- a/tests/util.py
+++ b/tests/util.py
@@ -31,7 +31,7 @@
 
 
 import os, sys
-from distutils.util import get_platform
+from sysconfig import get_platform
 
 #
 # prepare sys.path in case we are still in the build directory


### PR DESCRIPTION
Small fixes and cibuildwheel upgrade to enable 3.12 support. Wheels can be found on [TestPyPI](https://test.pypi.org/project/python-lzo/) if needed before the next release.